### PR TITLE
Remove argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
 tabulate
-argparse


### PR DESCRIPTION
`argparse` is a [standard module](https://docs.python.org/3/library/argparse.html).